### PR TITLE
Add Codex onboarding guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Agent Onboarding
+
+Before making code changes in this repository, read these files in order:
+
+1. `FABLE.md` - AI-agent handoff guide and modernization roadmap for Chassis.
+2. `README.md` - project purpose, public API examples, and current user-facing context.
+3. `CONTRIBUTING.md` - style and lint expectations.
+
+There is no root `CLAUDE.md` at the time of writing. If one is added later, treat it as
+the project constitution unless repository context says otherwise.
+
+When documentation, comments, and source code disagree, source code is authoritative
+unless the user explicitly asks to update documentation.


### PR DESCRIPTION
## Summary
- add root AGENTS.md for future Codex sessions
- point agents to FABLE.md, README.md, and CONTRIBUTING.md before code changes
- document the source-code authority rule

## Validation
- docs-only change; reviewed staged diff
- tests not run; docs-only change